### PR TITLE
Hide localhackday18, update logic to hide events that have ended

### DIFF
--- a/_events/localhackday2018.md
+++ b/_events/localhackday2018.md
@@ -1,7 +1,7 @@
 ---
 name: "Local Hack Day 2018"
 is-public: true
-is-over: false
+is-over: true
 
 start: "2018-12-01T09:00:00+00:00"
 end: "2018-12-01T19:30:00+00:00"

--- a/_home-sections/futureevents.html
+++ b/_home-sections/futureevents.html
@@ -5,6 +5,7 @@
             {% assign sorted-events = site.events | sort: 'start' %}
             {% for event in sorted-events %}
                 {% if event.is-public %}
+                    {% if event.is-over == false %}
                     <div class="card col-sm-6 col-md-3" style="border-width: 1px; border-color: {{ event.color }};">
                         <a href="/{{ event.slug }}"></a>
                         <div class="card-body">
@@ -13,6 +14,7 @@
                             <p class="card-text align-bottom">{{ event.short-description }}</p>
                         </div>
                     </div>
+                    {% endif %}
                 {% endif %}
             {% endfor %}
         </div>


### PR DESCRIPTION
Doesn't deal with any fancy data types (like dates) so should be safe.
Hides local hack day, and checks the is-over variable when displaying events in futureevents (on the main page).